### PR TITLE
Cleanup abandoned SQS queues

### DIFF
--- a/lib/realm/event_router.rb
+++ b/lib/realm/event_router.rb
@@ -38,6 +38,10 @@ module Realm
       end
     end
 
+    def cleanup
+      @gateways.each { |gateway| gateway.try(:cleanup) }
+    end
+
     private
 
     def init_gateways(gateways_spec)

--- a/lib/realm/event_router.rb
+++ b/lib/realm/event_router.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/string'
 require 'active_support/core_ext/hash'
 require 'realm/error'

--- a/lib/realm/event_router.rb
+++ b/lib/realm/event_router.rb
@@ -39,7 +39,7 @@ module Realm
     end
 
     def cleanup
-      @gateways.each { |gateway| gateway.try(:cleanup) }
+      @gateways.each { |(_, gateway)| gateway.cleanup }
     end
 
     private
@@ -78,7 +78,7 @@ module Realm
     end
 
     def gateway_for(namespace)
-      @gateways.fetch(namespace || default_namespace) do
+      @gateways.fetch(namespace.try(:to_sym) || default_namespace) do
         raise "No event gateway for #{namespace || 'default'} namespace" # TODO: extract error class
       end
     end

--- a/lib/realm/event_router/gateway.rb
+++ b/lib/realm/event_router/gateway.rb
@@ -27,8 +27,12 @@ module Realm
         raise NotImplementedError
       end
 
-      def worker
+      def worker(*)
         nil
+      end
+
+      def cleanup
+        # do nothing
       end
 
       protected

--- a/lib/realm/event_router/sns_gateway.rb
+++ b/lib/realm/event_router/sns_gateway.rb
@@ -41,7 +41,7 @@ module Realm
 
       # Cleans up empty abandoned queues and subscriptions (for cases when event handler was removed or renamed)
       def cleanup
-        queue_manager.cleanup(except: @queue_map.values)
+        queue_manager.cleanup(except: @queue_map.keys)
       end
 
       private

--- a/lib/realm/event_router/sns_gateway/queue_adapter.rb
+++ b/lib/realm/event_router/sns_gateway/queue_adapter.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
+require 'realm/event_router/gateway'
+require 'realm/mixins/decorator'
+
 module Realm
   class EventRouter
     class SNSGateway < Gateway
+      # Provides cleaner SDK over Aws::SQS::Queue
       class QueueAdapter
-        # Provides cleaner SDK over Aws::SQS::Queue
-        def initialize(queue)
-          @queue = queue
-        end
+        include Mixins::Decorator[:@queue]
 
         def arn
           @queue.attributes['QueueArn']
@@ -29,12 +30,12 @@ module Realm
           )
         end
 
-        def method_missing(name, *args)
-          @queue.send(name, *args)
-        end
-
-        def respond_to_missing?(name)
-          @queue.respond_to?(name)
+        def empty?
+          attributes.slice(
+            'ApproximateNumberOfMessages',
+            'ApproximateNumberOfMessagesDelayed',
+            'ApproximateNumberOfMessagesNotVisible',
+          ).all? { |_, val| val.to_i == 0 }
         end
 
         private

--- a/lib/realm/event_router/sns_gateway/queue_adapter.rb
+++ b/lib/realm/event_router/sns_gateway/queue_adapter.rb
@@ -35,7 +35,7 @@ module Realm
             'ApproximateNumberOfMessages',
             'ApproximateNumberOfMessagesDelayed',
             'ApproximateNumberOfMessagesNotVisible',
-          ).all? { |_, val| val.to_i == 0 }
+          ).all? { |_, val| val.to_i.zero? }
         end
 
         private

--- a/lib/realm/event_router/sns_gateway/queue_manager.rb
+++ b/lib/realm/event_router/sns_gateway/queue_manager.rb
@@ -1,20 +1,35 @@
 # frozen_string_literal: true
 
 require 'aws-sdk-sqs'
+require 'realm/error'
 require_relative './queue_adapter'
 
 module Realm
   class EventRouter
     class SNSGateway < Gateway
       class QueueManager
-        def initialize(sqs: Aws::SQS::Resource.new)
+        QueueNameTooLong = Realm::Error[
+          "Queue name can be 80 chars long max, please provide custom EventHandler identifier if it's auto generated"]
+
+        CleanupWithoutPrefix = Realm::Error[
+          'Cleaning up queues without prefix is not allowed, it can lead to deleting queues from other apps']
+
+        def initialize(prefix: nil, sqs: Aws::SQS::Resource.new)
+          @prefix = prefix
           @sqs = sqs
         end
 
         def get(name: nil, arn: nil)
           throw ArgumentError, 'You have to provide name or arn of the queue' unless name || arn
 
-          QueueAdapter.new(@sqs.get_queue_by_name(queue_name: name || arn.split(':')[-1]))
+          QueueAdapter.new(@sqs.get_queue_by_name(queue_name: name ? prefix_name(name) : arn.split(':')[-1]))
+        end
+
+        def create(queue_name)
+          name = prefix_name(queue_name)
+          raise QueueNameTooLong if name.size > 80
+
+          QueueAdapter.new(@sqs.create_queue(queue_name: name))
         end
 
         def provide(queue_name)
@@ -23,8 +38,21 @@ module Realm
           create(queue_name)
         end
 
-        def create(queue_name)
-          QueueAdapter.new(@sqs.create_queue(queue_name: queue_name))
+        def cleanup(except: [])
+          raise CleanupWithoutPrefix unless @prefix
+
+          except_urls = Array(except).map(&:url)
+          @sqs.queues(queue_name_prefix: @prefix).each do |queue|
+            next if except_urls.include?(queue.url)
+
+            queue.delete if QueueAdapter.new(queue).empty?
+          end
+        end
+
+        private
+
+        def prefix_name(name)
+          [@prefix, name].compact.join('-')
         end
       end
     end

--- a/lib/realm/mixins/decorator.rb
+++ b/lib/realm/mixins/decorator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Realm
+  module Mixins
+    module Decorator
+      def self.[](decorated) # rubocop:disable Metrics/MethodLength
+        Module.new do
+          def method_missing(...)
+            _decorated.send(...)
+          end
+
+          def respond_to_missing?(...)
+            _decorated.respond_to?(...)
+          end
+
+          if decorated.to_s[0] == '@'
+            define_method :initialize do |value|
+              instance_variable_set(decorated, value)
+            end
+
+            define_method :_decorated do
+              instance_variable_get(decorated)
+            end
+          else
+            define_method :_decorated do
+              send(decorated)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/realm/runtime.rb
+++ b/lib/realm/runtime.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/try'
 require 'realm/dispatcher'
 require 'realm/event_router'
 require 'realm/multi_worker'
@@ -36,6 +37,10 @@ module Realm
         map[name] = component.health if component.respond_to?(:health)
       end
       HealthStatus.combine(component_statuses)
+    end
+
+    def cleanup
+      @event_router.try(:cleanup)
     end
 
     private

--- a/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
+++ b/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe Realm::EventRouter::SNSGateway::QueueManager do
 
     it 'refuses to cleanup without prefix' do
       expect { described_class.new.cleanup(except: used_queue) }.to raise_error(
-        Realm::EventRouter::SNSGateway::QueueManager::CleanupWithoutPrefix)
+        Realm::EventRouter::SNSGateway::QueueManager::CleanupWithoutPrefix,
+      )
     end
   end
 end

--- a/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
+++ b/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'realm/event_router/sns_gateway/queue_manager'
+require 'realm/event_router/sns_gateway/queue_adapter'
+
+require 'aws-sdk-core'
+require 'aws-sdk-sns'
+
+Aws.config.update(endpoint: ENV.fetch('AWS_ENDPOINT'))
+
+RSpec.describe Realm::EventRouter::SNSGateway::QueueManager do
+  let(:sqs) { Aws::SQS::Resource.new }
+  let(:queue_names) { sqs.queues.map { |q| q.url.sub(%r{^.*/}, '') } }
+
+  subject { described_class.new(prefix: 'test_prefix') }
+
+  after do
+    sqs.queues.each(&:delete)
+  end
+
+  describe '#get' do
+    let!(:existing_queue) { sqs.create_queue(queue_name: 'test_prefix-sample_queue') }
+
+    it 'returns queue by name' do
+      queue = subject.get(name: 'sample_queue')
+      expect(queue).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
+      expect(queue.url).to eq existing_queue.url
+    end
+
+    it 'returns queue by arn' do
+      queue = subject.get(arn: existing_queue.attributes['QueueArn'])
+      expect(queue).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
+      expect(queue.url).to eq existing_queue.url
+    end
+  end
+
+  describe '#create' do
+    it 'creates prefixed queue' do
+      queue = subject.create('sample_queue')
+      expect(queue).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
+      expect(sqs.get_queue_by_name(queue_name: 'test_prefix-sample_queue').url).to eq queue.url
+    end
+  end
+
+  describe '#provide' do
+    let!(:existing_queue) { sqs.create_queue(queue_name: 'test_prefix-sample_queue') }
+
+    it 'retrieves queue if exists' do
+      queue = subject.provide('sample_queue')
+      expect(queue).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
+      expect(sqs.get_queue_by_name(queue_name: 'test_prefix-sample_queue').url).to eq existing_queue.url
+    end
+
+    it 'creates queue if does not exist' do
+      queue = subject.provide('another_queue')
+      expect(queue).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
+      expect(sqs.get_queue_by_name(queue_name: 'test_prefix-another_queue').url).to eq queue.url
+    end
+  end
+
+  describe '#cleanup' do
+    let!(:used_queue) { subject.create('used_queue') }
+    let!(:empty_abandoned_queue) { subject.create('empty_abandoned_queue') }
+    let!(:abandoned_queue) do
+      subject.create('abandoned_queue').tap do |queue|
+        queue.send_message(message_body: 'sample body')
+      end
+    end
+
+    it 'deletes empty abandoned queues' do
+      expect { subject.cleanup(except: used_queue) }.to change { sqs.queues.to_a.size }.from(3).to(2)
+      expect(queue_names).to include('test_prefix-used_queue', 'test_prefix-abandoned_queue')
+    end
+  end
+end

--- a/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
+++ b/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
@@ -72,5 +72,10 @@ RSpec.describe Realm::EventRouter::SNSGateway::QueueManager do
       expect { subject.cleanup(except: used_queue) }.to change { sqs.queues.to_a.size }.from(3).to(2)
       expect(queue_names).to include('test_prefix-used_queue', 'test_prefix-abandoned_queue')
     end
+
+    it 'refuses to cleanup without prefix' do
+      expect { described_class.new.cleanup(except: used_queue) }.to raise_error(
+        Realm::EventRouter::SNSGateway::QueueManager::CleanupWithoutPrefix)
+    end
   end
 end

--- a/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
+++ b/spec/realm/event_router/sns_gateway/queue_manager_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Realm::EventRouter::SNSGateway::QueueManager do
       end
     end
 
-    it 'deletes empty abandoned queues' do
+    it 'deletes empty queues which are not skipped' do
       expect { subject.cleanup(except: used_queue) }.to change { sqs.queues.to_a.size }.from(3).to(2)
       expect(queue_names).to include('test_prefix-used_queue', 'test_prefix-abandoned_queue')
     end

--- a/spec/realm/event_router/sns_gateway_spec.rb
+++ b/spec/realm/event_router/sns_gateway_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Realm::EventRouter::SNSGateway do
   end
 
   after do
-    subject.purge!
+    sqs.queues.each(&:delete)
   end
 
   context 'with specific event listener' do
@@ -117,7 +117,7 @@ RSpec.describe Realm::EventRouter::SNSGateway do
     it 'raises error' do
       expect {
         subject.register(SNSGatewaySpec::VeryLongLongLongLongLongLongLongLongLongLongLongLongLongLongNameHandler)
-      }.to raise_error(Realm::EventRouter::SNSGateway::QueueNameTooLong)
+      }.to raise_error(Realm::EventRouter::SNSGateway::QueueManager::QueueNameTooLong)
     end
   end
 

--- a/spec/realm/event_router/sns_gateway_spec.rb
+++ b/spec/realm/event_router/sns_gateway_spec.rb
@@ -128,4 +128,14 @@ RSpec.describe Realm::EventRouter::SNSGateway do
       expect(queue_names).to include('something_happened-short_and_sweet')
     end
   end
+
+  describe '#cleanup' do
+    it 'calls cleanup on queue manager passing the current queues to skip' do
+      expect_any_instance_of(Realm::EventRouter::SNSGateway::QueueManager).to receive(:cleanup).with(
+        except: [kind_of(Realm::EventRouter::SNSGateway::QueueAdapter)],
+      )
+      subject.register(SNSGatewaySpec::SampleHandler)
+      subject.cleanup
+    end
+  end
 end

--- a/spec/realm/event_router_spec.rb
+++ b/spec/realm/event_router_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'realm/event'
+require 'realm/event_router'
+require 'realm/event_router/internal_loop_gateway'
+require_relative 'support/runtime_mock'
+
+module EventRouterSpec
+  class Ns1SampleHandler < Realm::EventHandler
+    namespace :ns1
+  end
+
+  class SampleHandler < Realm::EventHandler
+  end
+end
+
+
+RSpec.describe Realm::EventRouter do
+  let(:stack) { [] }
+  let(:runtime) { RuntimeMock.new(context: { stack: stack }) }
+  let(:gateways_spec) do
+    {
+      ns1: { type: :internal_loop, events_module: EventRouterSpec },
+      ns2: { type: :internal_loop, events_module: EventRouterSpec, default: true },
+    }
+  end
+  let(:gateway1) { instance_double(Realm::EventRouter::InternalLoopGateway) }
+  let(:gateway2) { instance_double(Realm::EventRouter::InternalLoopGateway) }
+  subject { described_class.new(gateways_spec, runtime: runtime, prefix: 'test-prefix') }
+
+  before do
+    expect(Realm::EventRouter::InternalLoopGateway).to receive(:new)
+      .with(hash_including(namespace: :ns1)).and_return(gateway1)
+    expect(Realm::EventRouter::InternalLoopGateway).to receive(:new)
+      .with(hash_including(namespace: :ns2)).and_return(gateway2)
+  end
+
+  describe '#register' do
+    it 'registers event handler to gateway corresponding to handler namespace' do
+      expect(gateway1).to receive(:register).with(EventRouterSpec::Ns1SampleHandler)
+      subject.register(EventRouterSpec::Ns1SampleHandler)
+    end
+
+    it 'registers event handler to default gateway if no handler namespace is specified' do
+      expect(gateway2).to receive(:register).with(EventRouterSpec::SampleHandler)
+      subject.register(EventRouterSpec::SampleHandler)
+    end
+  end
+
+  describe '#add_listener' do
+    it 'adds listener on gateway for corresponding namespace' do
+      expect(gateway1).to receive(:add_listener).with(:event_type1, :listener1)
+      subject.add_listener(:event_type1, :listener1, namespace: :ns1)
+    end
+
+    it 'adds listener on default gateway if no namespace is specified' do
+      expect(gateway2).to receive(:add_listener).with(:event_type2, :listener2)
+      subject.add_listener(:event_type2, :listener2)
+    end
+  end
+
+  describe '#trigger' do
+    it 'triggers event on gateway for corresponding namespace' do
+      expect(gateway1).to receive(:trigger).with('sample', foo: 123)
+      subject.trigger('ns1.sample', foo: 123)
+
+      expect(gateway2).to receive(:trigger).with('sample', foo: 456)
+      subject.trigger('ns2.sample', foo: 456)
+    end
+
+    it 'triggers event on default gateway if no namespace is specified' do
+      expect(gateway2).to receive(:trigger).with(:sample, foo: 123)
+      subject.trigger(:sample, foo: 123)
+    end
+  end
+
+  describe '#workers' do
+    it 'calls worker method on gateway for corresponding namespace' do
+      expect(gateway1).to receive(:worker).with(foo: 123)
+      subject.workers(:ns1, foo: 123)
+
+      expect(gateway2).to receive(:worker).with(foo: 456)
+      subject.workers(:ns2, foo: 456)
+    end
+
+    it 'calls worker method on all gateways if no namespace is specified' do
+      expect(gateway1).to receive(:worker).with(foo: 123)
+      expect(gateway2).to receive(:worker).with(foo: 123)
+      subject.workers(foo: 123)
+    end
+  end
+
+  describe '#cleanup' do
+    it 'calls cleanup method on all gateways' do
+      expect(gateway1).to receive(:cleanup)
+      expect(gateway2).to receive(:cleanup)
+      subject.cleanup
+    end
+  end
+end

--- a/spec/realm/event_router_spec.rb
+++ b/spec/realm/event_router_spec.rb
@@ -15,7 +15,6 @@ module EventRouterSpec
   end
 end
 
-
 RSpec.describe Realm::EventRouter do
   let(:stack) { [] }
   let(:runtime) { RuntimeMock.new(context: { stack: stack }) }

--- a/spec/realm/runtime_spec.rb
+++ b/spec/realm/runtime_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe Realm::Runtime do
     end
   end
 
+  describe '#cleanup' do
+    let(:event_gateways_config) { { default: { type: :internal_loop, events_module: Module.new } } }
+    subject do
+      described_class.new(
+        event_gateways_config: event_gateways_config,
+        domain_resolver: domain_resolver,
+        context: context,
+      )
+    end
+
+    it 'calls cleanup on event router' do
+      expect_any_instance_of(Realm::EventRouter).to receive(:cleanup)
+      subject.cleanup
+    end
+  end
+
   %i[query run run_as_job].each do |method|
     describe "##{method}" do
       it 'passes the call down to dispatcher' do


### PR DESCRIPTION
We autogenerate the SQS queues for `EventHandler` classes based on their name. If handler is removed or renamed the abandoned queue and subscription stays. This PR adds cleanup logic that could be run from job of the app.