### PR TITLE
Expose active queues across all realm runtimes

### DIFF
--- a/lib/realm/event_router.rb
+++ b/lib/realm/event_router.rb
@@ -37,8 +37,10 @@ module Realm
       end
     end
 
-    def cleanup
-      @gateways.each { |(_, gateway)| gateway.cleanup }
+    def active_queues
+      @gateways.values.reduce([]) do |queues, gateway|
+        queues + gateway.queues
+      end
     end
 
     private

--- a/lib/realm/event_router/gateway.rb
+++ b/lib/realm/event_router/gateway.rb
@@ -35,6 +35,10 @@ module Realm
         # do nothing
       end
 
+      def queues
+        []
+      end
+
       protected
 
       def create_event(event_type, attributes = {})

--- a/lib/realm/event_router/sns_gateway.rb
+++ b/lib/realm/event_router/sns_gateway.rb
@@ -39,9 +39,8 @@ module Realm
         )
       end
 
-      # Cleans up empty abandoned queues and subscriptions (for cases when event handler was removed or renamed)
-      def cleanup
-        queue_manager.cleanup(except: @queue_map.keys)
+      def queues
+        @queue_map.keys
       end
 
       private

--- a/lib/realm/runtime.rb
+++ b/lib/realm/runtime.rb
@@ -40,8 +40,8 @@ module Realm
     end
 
     # Get all active messaging queues. For maintenance purpose only.
-    # TODO: introduce component container and allow to call those method directly on components instead of
-    # polluting realtime
+    # TODO: Introduce component container and allow to call those method directly on components instead of
+    # polluting runtime
     # Example: engine.realm.components.find(type: Realm::EventRouter::SNSGateway).try(:active_queues)
     def active_queues
       @event_router.active_queues

--- a/lib/realm/runtime.rb
+++ b/lib/realm/runtime.rb
@@ -39,8 +39,12 @@ module Realm
       HealthStatus.combine(component_statuses)
     end
 
-    def cleanup
-      @event_router.try(:cleanup)
+    # Get all active messaging queues. For maintenance purpose only.
+    # TODO: introduce component container and allow to call those method directly on components instead of
+    # polluting realtime
+    # Example: engine.realm.components.find(type: Realm::EventRouter::SNSGateway).try(:active_queues)
+    def active_queues
+      @event_router.active_queues
     end
 
     private

--- a/spec/realm/event_router/sns_gateway_spec.rb
+++ b/spec/realm/event_router/sns_gateway_spec.rb
@@ -129,13 +129,13 @@ RSpec.describe Realm::EventRouter::SNSGateway do
     end
   end
 
-  describe '#cleanup' do
-    it 'calls cleanup on queue manager passing the current queues to skip' do
-      expect_any_instance_of(Realm::EventRouter::SNSGateway::QueueManager).to receive(:cleanup).with(
-        except: [kind_of(Realm::EventRouter::SNSGateway::QueueAdapter)],
-      )
+  describe '#queues' do
+    it 'returns all active queues' do
       subject.register(SNSGatewaySpec::SampleHandler)
-      subject.cleanup
+      subject.register(SNSGatewaySpec::SampleAnyHandler)
+      expect(subject.queues.size).to eq 2
+      expect(subject.queues[0]).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
+      expect(subject.queues[1]).to be_a Realm::EventRouter::SNSGateway::QueueAdapter
     end
   end
 end

--- a/spec/realm/event_router_spec.rb
+++ b/spec/realm/event_router_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe Realm::EventRouter do
     end
   end
 
-  describe '#cleanup' do
-    it 'calls cleanup method on all gateways' do
-      expect(gateway1).to receive(:cleanup)
-      expect(gateway2).to receive(:cleanup)
-      subject.cleanup
+  describe '#active_queues' do
+    it 'collects queues from all gateways' do
+      expect(gateway1).to receive(:queues).and_return([:queue1])
+      expect(gateway2).to receive(:queues).and_return([:queue2])
+      expect(subject.active_queues).to eq([:queue1, :queue2])
     end
   end
 end

--- a/spec/realm/event_router_spec.rb
+++ b/spec/realm/event_router_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Realm::EventRouter do
     it 'collects queues from all gateways' do
       expect(gateway1).to receive(:queues).and_return([:queue1])
       expect(gateway2).to receive(:queues).and_return([:queue2])
-      expect(subject.active_queues).to eq([:queue1, :queue2])
+      expect(subject.active_queues).to eq(%i[queue1 queue2])
     end
   end
 end

--- a/spec/realm/runtime_spec.rb
+++ b/spec/realm/runtime_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Realm::Runtime do
     end
   end
 
-  describe '#cleanup' do
+  describe '#active_queues' do
     let(:event_gateways_config) { { default: { type: :internal_loop, events_module: Module.new } } }
     subject do
       described_class.new(
@@ -59,9 +59,9 @@ RSpec.describe Realm::Runtime do
       )
     end
 
-    it 'calls cleanup on event router' do
-      expect_any_instance_of(Realm::EventRouter).to receive(:cleanup)
-      subject.cleanup
+    it 'calls active_queues on event router' do
+      expect_any_instance_of(Realm::EventRouter).to receive(:active_queues)
+      subject.active_queues
     end
   end
 


### PR DESCRIPTION
The approach for cleaning SQS queues introduced in https://github.com/reevoo/realm/pull/4 actually doesn't work. We cannot run cleanup in each realm runtime separately because it would delete queues from other runtimes. We have to instead collect all active queues from all runtimes and run the cleanup just once from the root app.