### PR TITLE
Active queues fix

### DIFF
--- a/lib/realm/event_router.rb
+++ b/lib/realm/event_router.rb
@@ -38,6 +38,7 @@ module Realm
     end
 
     def active_queues
+      auto_register_handlers
       @gateways.values.reduce([]) do |queues, gateway|
         queues + gateway.queues
       end

--- a/lib/realm/runtime.rb
+++ b/lib/realm/runtime.rb
@@ -44,7 +44,7 @@ module Realm
     # polluting runtime
     # Example: engine.realm.components.find(type: Realm::EventRouter::SNSGateway).try(:active_queues)
     def active_queues
-      @event_router.active_queues
+      @event_router.try(:active_queues) || []
     end
 
     private

--- a/spec/realm/event_router_spec.rb
+++ b/spec/realm/event_router_spec.rb
@@ -101,8 +101,10 @@ RSpec.describe Realm::EventRouter do
     end
 
     context 'with domain resolver' do
-      let(:domain_resolver) { double(:domain_resolver, all_event_handlers: [:handler1] ) }
-      subject { described_class.new(gateways_spec, runtime: runtime, prefix: 'test-prefix', domain_resolver: domain_resolver) }
+      let(:domain_resolver) { double(:domain_resolver, all_event_handlers: [:handler1]) }
+      subject do
+        described_class.new(gateways_spec, runtime: runtime, prefix: 'test-prefix', domain_resolver: domain_resolver)
+      end
 
       it 'triggers auto registration of event handlers' do
         expect(gateway2).to receive(:register).with(:handler1)

--- a/spec/realm/event_router_spec.rb
+++ b/spec/realm/event_router_spec.rb
@@ -91,10 +91,23 @@ RSpec.describe Realm::EventRouter do
   end
 
   describe '#active_queues' do
-    it 'collects queues from all gateways' do
+    before do
       expect(gateway1).to receive(:queues).and_return([:queue1])
       expect(gateway2).to receive(:queues).and_return([:queue2])
+    end
+
+    it 'collects queues from all gateways' do
       expect(subject.active_queues).to eq(%i[queue1 queue2])
+    end
+
+    context 'with domain resolver' do
+      let(:domain_resolver) { double(:domain_resolver, all_event_handlers: [:handler1] ) }
+      subject { described_class.new(gateways_spec, runtime: runtime, prefix: 'test-prefix', domain_resolver: domain_resolver) }
+
+      it 'triggers auto registration of event handlers' do
+        expect(gateway2).to receive(:register).with(:handler1)
+        subject.active_queues
+      end
     end
   end
 end


### PR DESCRIPTION
We have to register event handlers first to be able to retrieve active queues