### PR TITLE
Config refactoring

### DIFF
--- a/realm-core/lib/realm/builder.rb
+++ b/realm-core/lib/realm/builder.rb
@@ -63,7 +63,7 @@ module Realm
 
     def setup_plugins
       Plugin.descendants.each do |plugin|
-        plugin.setup(cfg, container) if cfg.plugins.include?(plugin.name)
+        plugin.setup(cfg, container) if cfg.plugins.include?(plugin.plugin_name)
       end
     end
 

--- a/realm-core/lib/realm/builder.rb
+++ b/realm-core/lib/realm/builder.rb
@@ -70,26 +70,13 @@ module Realm
     def config_persistence
       return unless cfg.persistence_gateway.present?
 
-      options = persistence_defaults.merge(cfg.persistence_gateway)
-      Persistence.setup(cfg.root_module, options)
+      Persistence.setup(cfg.root_module, cfg.persistence_gateway)
     end
 
     def constantize(*parts)
       return parts[0] unless parts[0].is_a?(String)
 
       parts.join('::').safe_constantize
-    end
-
-    def persistence_defaults
-      class_path = cfg.engine_path && "#{cfg.engine_path}/app/persistence/#{cfg.namespace}"
-      {
-        type: :rom,
-        container: @container,
-        class_path: class_path,
-        repos_path: class_path && "#{class_path}/repositories",
-        repos_module: "#{cfg.root_module}::Repositories",
-        migration_path: cfg.engine_path && "#{cfg.engine_path}/db/migrate",
-      }
     end
 
     def cfg

--- a/realm-core/lib/realm/config.rb
+++ b/realm-core/lib/realm/config.rb
@@ -17,7 +17,7 @@ module Realm
     option :logger,               default: proc {}
     option :plugins,              default: proc { [] }, reader: false
     option :dependencies,         default: proc { {} }
-    option :persistence_gateway,  default: proc { database_url && { url: database_url } }
+    option :persistence_gateway,  default: proc { database_url && { type: :rom, url: database_url } }, reader: false
     option :event_gateway,        default: proc {}, reader: false
     option :event_gateways,       default: proc {
       @event_gateway ? { default: { **@event_gateway, default: true } } : {}
@@ -25,6 +25,18 @@ module Realm
 
     def plugins
       Array(@plugins)
+    end
+
+    def persistence_gateway
+      return unless @persistence_gateway
+
+      class_path = engine_path && "#{engine_path}/app/persistence/#{namespace}"
+      {
+        class_path: class_path,
+        repos_path: class_path && "#{class_path}/repositories",
+        repos_module: "#{root_module}::Repositories",
+        migration_path: engine_path && "#{engine_path}/db/migrate",
+      }.merge(@persistence_gateway)
     end
   end
 end

--- a/realm-core/lib/realm/plugin.rb
+++ b/realm-core/lib/realm/plugin.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/class'
-require 'dry-core'
+require 'active_support/core_ext/string'
 
 module Realm
   class Plugin
-    extend Dry::Core::ClassAttributes
+    class << self
+      def plugin_name(value = :not_provided)
+        @plugin_name = value.to_sym unless value == :not_provided
+        @plugin_name = name.split('::')[-2].underscore.to_sym unless defined?(@plugin_name)
+        @plugin_name
+      end
 
-    defines :name
-
-    def self.setup(_config, _container)
-      raise NotImplementedError
+      def setup(_config, _container)
+        raise NotImplementedError
+      end
     end
   end
 end


### PR DESCRIPTION
- Move persistence gateway defaults to Config class
- Rename Plugin.name to Plugin.plugin_name to avoid conflict with Class.name