### PR TITLE
Meta extraction in events

### DIFF
--- a/realm-core/lib/realm/event.rb
+++ b/realm-core/lib/realm/event.rb
@@ -38,7 +38,7 @@ module Realm
       end
 
       def attributes_with_meta
-        @attributes_with_meta ||= collect_attributes_with_meta(self::Body)
+        @attributes_with_meta ||= collect_attributes_with_meta(schema.key(:body).type)
       end
 
       protected

--- a/realm-core/lib/realm/event.rb
+++ b/realm-core/lib/realm/event.rb
@@ -49,7 +49,7 @@ module Realm
 
       private
 
-      def collect_attributes_with_meta(thing, path = [])
+      def collect_attributes_with_meta(thing, path = []) # rubocop:disable Metrics/AbcSize
         if thing.respond_to?(:schema) # struct
           thing.schema.keys.reduce({}) do |memo, key|
             memo.merge(collect_attributes_with_meta(key.type, path + [key.name]))

--- a/realm-core/lib/realm/event.rb
+++ b/realm-core/lib/realm/event.rb
@@ -37,8 +37,8 @@ module Realm
         @type ||= name.demodulize.sub('Event', '').underscore
       end
 
-      def attributes_with_meta
-        @attributes_with_meta ||= collect_attributes_with_meta(schema.key(:body).type)
+      def flatten_attributes_meta
+        @flatten_attributes_meta ||= collect_attributes_meta(schema.key(:body).type)
       end
 
       protected
@@ -49,13 +49,13 @@ module Realm
 
       private
 
-      def collect_attributes_with_meta(thing, path = []) # rubocop:disable Metrics/AbcSize
+      def collect_attributes_meta(thing, path = []) # rubocop:disable Metrics/AbcSize
         if thing.respond_to?(:schema) && thing.constructor_type != Dry::Types::Hash::Constructor # struct
           thing.schema.keys.reduce({}) do |memo, key|
-            memo.merge(collect_attributes_with_meta(key.type, path + [key.name]))
+            memo.merge(collect_attributes_meta(key.type, path + [key.name]))
           end
         elsif thing.constructor_type == Dry::Types::Array::Constructor # array
-          collect_attributes_with_meta(thing.type.member, path + [:[]])
+          collect_attributes_meta(thing.type.member, path + [:[]])
         else
           thing.meta.present? ? { path => thing.meta } : {}
         end

--- a/realm-core/lib/realm/event.rb
+++ b/realm-core/lib/realm/event.rb
@@ -50,7 +50,7 @@ module Realm
       private
 
       def collect_attributes_with_meta(thing, path = []) # rubocop:disable Metrics/AbcSize
-        if thing.respond_to?(:schema) # struct
+        if thing.respond_to?(:schema) && thing.constructor_type != Dry::Types::Hash::Constructor # struct
           thing.schema.keys.reduce({}) do |memo, key|
             memo.merge(collect_attributes_with_meta(key.type, path + [key.name]))
           end

--- a/realm-core/spec/realm/contract_spec.rb
+++ b/realm-core/spec/realm/contract_spec.rb
@@ -46,7 +46,11 @@ RSpec.describe Realm::Contract do
 
   it 'supports combination of struct, attributes and standard schema' do
     contract = CombinedContract.new
+<<<<<<< HEAD
     expect(contract.(foo: 'ab', another: 'c').errors.to_h).to eq(
+=======
+    expect(contract.({foo: 'ab', another: 'c'}).errors.to_h).to eq(
+>>>>>>> 189d758 (Add test for combined schema)
       foo: ['size cannot be less than 3'], bar: ['is missing'], another: ['must be an integer'],
     )
   end

--- a/realm-core/spec/realm/contract_spec.rb
+++ b/realm-core/spec/realm/contract_spec.rb
@@ -46,11 +46,7 @@ RSpec.describe Realm::Contract do
 
   it 'supports combination of struct, attributes and standard schema' do
     contract = CombinedContract.new
-<<<<<<< HEAD
     expect(contract.(foo: 'ab', another: 'c').errors.to_h).to eq(
-=======
-    expect(contract.({foo: 'ab', another: 'c'}).errors.to_h).to eq(
->>>>>>> 189d758 (Add test for combined schema)
       foo: ['size cannot be less than 3'], bar: ['is missing'], another: ['must be an integer'],
     )
   end

--- a/realm-core/spec/realm/event_spec.rb
+++ b/realm-core/spec/realm/event_spec.rb
@@ -25,6 +25,19 @@ module TestEvents
   # class HashTypeEvent < Realm::Event
   #   body_struct MyType
   # end
+
+  class EventWithMeta < Realm::Event
+    body_struct do
+      attribute :foo, T::String.meta(meta1: 'x', meta2: 2)
+      attribute :another, T::Integer
+      attribute :bar do
+        attribute :inner, T::String.meta(meta3: 3)
+      end
+      attribute :baz, T::Array do
+        attribute :member, T::String.meta(meta4: 4)
+      end
+    end
+  end
 end
 
 RSpec.describe Realm::Event do
@@ -39,6 +52,16 @@ RSpec.describe Realm::Event do
 
     it 'supports inline struct' do
       expect(TestEvents::InlineStructEvent.new(foo: 'hi').body.foo).to eq 'hi'
+    end
+  end
+
+  describe '.attributes_with_meta' do
+    it 'returns map from attribute path to meta values if present' do
+      expect(TestEvents::EventWithMeta.attributes_with_meta).to eq(
+        [:foo] => { meta1: 'x', meta2: 2 },
+        [:bar, :inner] => { meta3: 3 },
+        [:baz, :[], :member] => { meta4: 4 },
+      )
     end
   end
 end

--- a/realm-core/spec/realm/event_spec.rb
+++ b/realm-core/spec/realm/event_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Realm::Event do
     end
   end
 
-  describe '.attributes_with_meta' do
+  describe '.flatten_attributes_meta' do
     it 'returns map from attribute path to meta values if present' do
-      expect(TestEvents::EventWithMeta.attributes_with_meta).to eq(
+      expect(TestEvents::EventWithMeta.flatten_attributes_meta).to eq(
         [:foo] => { meta1: 'x', meta2: 2 },
         %i[bar inner] => { meta3: 3 },
         %i(baz [] member) => { meta4: 4 },
@@ -69,7 +69,7 @@ RSpec.describe Realm::Event do
     end
 
     it 'handles free structure events' do
-      expect(TestEvents::FreeStructureEvent.attributes_with_meta).to eq({})
+      expect(TestEvents::FreeStructureEvent.flatten_attributes_meta).to eq({})
     end
   end
 end

--- a/realm-core/spec/realm/event_spec.rb
+++ b/realm-core/spec/realm/event_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Realm::Event do
     it 'returns map from attribute path to meta values if present' do
       expect(TestEvents::EventWithMeta.attributes_with_meta).to eq(
         [:foo] => { meta1: 'x', meta2: 2 },
-        [:bar, :inner] => { meta3: 3 },
-        [:baz, :[], :member] => { meta4: 4 },
+        %i[bar inner] => { meta3: 3 },
+        %i(baz [] member) => { meta4: 4 },
       )
     end
   end

--- a/realm-core/spec/realm/event_spec.rb
+++ b/realm-core/spec/realm/event_spec.rb
@@ -38,6 +38,10 @@ module TestEvents
       end
     end
   end
+
+  class FreeStructureEvent < Realm::Event
+    attribute :body, Realm::Types::Hash
+  end
 end
 
 RSpec.describe Realm::Event do
@@ -62,6 +66,10 @@ RSpec.describe Realm::Event do
         %i[bar inner] => { meta3: 3 },
         %i(baz [] member) => { meta4: 4 },
       )
+    end
+
+    it 'handles free structure events' do
+      expect(TestEvents::FreeStructureEvent.attributes_with_meta).to eq({})
     end
   end
 end

--- a/realm-sns/lib/realm/sns/gateway/worker.rb
+++ b/realm-sns/lib/realm/sns/gateway/worker.rb
@@ -83,7 +83,7 @@ module Realm
         end
 
         def message_to_event(msg)
-          event_type = msg.message_attributes['event_type'].string_value
+          event_type = msg.message_attributes['event_type']&.string_value
           raise 'Message is missing event type' unless event_type
 
           payload = JSON.parse(msg.body).deep_symbolize_keys


### PR DESCRIPTION
Dry types support meta attributes that we want to use to tag GDPR sensitive attributes like an email. To simplify usage of meta for processing I added `Event.flatten_attributes_meta` method that returns all meta values in a flat hash structure.